### PR TITLE
[Fix/Refactor] Improve clip item recyclerview performance 

### DIFF
--- a/XClipper.Android/app/src/main/kotlin/com/kpstv/xclipper/data/repository/MainRepositoryImpl.kt
+++ b/XClipper.Android/app/src/main/kotlin/com/kpstv/xclipper/data/repository/MainRepositoryImpl.kt
@@ -86,8 +86,9 @@ class MainRepositoryImpl @Inject constructor(
 
             /** Merge the existing tags into the clip tags */
             val newClip = if (finalClip.tags != null && clip.tags != null)
-                finalClip.copy(tags = (finalClip.tags!! + clip.tags!!))
-            else finalClip
+                finalClip.copyWithFields(tags = (finalClip.tags!! + clip.tags!!))
+            else
+                finalClip
 
             clipDao.update(newClip)
             true

--- a/XClipper.Android/build.gradle.kts
+++ b/XClipper.Android/build.gradle.kts
@@ -10,7 +10,6 @@ buildscript {
         classpath(GradleDependency.DAGGER_HILT)
         classpath(GradleDependency.CRASHLYTICS)
         classpath(GradleDependency.GOOGLE_SERVICE)
-      classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
     }
 }
 

--- a/XClipper.Android/buildSrc/src/main/java/AndroidConfig.kt
+++ b/XClipper.Android/buildSrc/src/main/java/AndroidConfig.kt
@@ -4,8 +4,8 @@ object AndroidConfig {
     const val TARGET_SDK_VERSION = 30
     const val BUILD_TOOLS_VERSION = "30.0.3"
 
-    const val VERSION_CODE = 28
-    const val VERSION_NAME = "1.2.3"
+    const val VERSION_CODE = 29
+    const val VERSION_NAME = "1.2.4"
 
     const val ID = "com.kpstv.xclipper"
     const val TEST_INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"

--- a/XClipper.Android/fastlane/Fastfile
+++ b/XClipper.Android/fastlane/Fastfile
@@ -20,7 +20,7 @@ platform :android do
   lane :beta do
     gradle(task: "app:checkForChangelog")
     gradle(task: "clean bundleRelease")
-    upload_to_play_store(track: 'beta')
+    upload_to_play_store(track: 'beta', skip_upload_metadata: true, skip_upload_images: true, skip_upload_screenshots: true)
   end
 end
 

--- a/XClipper.Android/modules/core-addons/build.gradle.kts
+++ b/XClipper.Android/modules/core-addons/build.gradle.kts
@@ -1,34 +1,34 @@
 plugins {
-  id(GradlePluginId.ANDROID_LIBRARY)
-  id(GradlePluginId.XCLIPPER_ANDROID)
-  kotlin(GradlePluginId.ANDROID_KTX)
-  kotlin(GradlePluginId.KAPT)
-  id(GradlePluginId.KOTLIN_PARCELIZE)
-  id(GradlePluginId.DAGGER_HILT)
+    id(GradlePluginId.ANDROID_LIBRARY)
+    id(GradlePluginId.XCLIPPER_ANDROID)
+    kotlin(GradlePluginId.ANDROID_KTX)
+    kotlin(GradlePluginId.KAPT)
+    id(GradlePluginId.KOTLIN_PARCELIZE)
+    id(GradlePluginId.DAGGER_HILT)
 }
 
 android {
-  buildFeatures.viewBinding = true
+    buildFeatures.viewBinding = true
 }
 
 dependencies {
-  implementation(project(ModuleDependency.CORE))
-  implementation(project(ModuleDependency.CORE_EXTENSIONS))
-  implementation(project(ModuleDependency.CORE_PINLOCK))
+    implementation(project(ModuleDependency.CORE))
+    implementation(project(ModuleDependency.CORE_EXTENSIONS))
+    implementation(project(ModuleDependency.CORE_PINLOCK))
 
-  implementation(LibraryDependency.CORE_KTX)
-  implementation(LibraryDependency.FRAGMENT_KTX)
-  implementation(LibraryDependency.MATERIAL)
-  implementation(LibraryDependency.LIFECYCLE_KTX)
-  implementation(LibraryDependency.BILLING)
-  implementation(LibraryDependency.NAVIGATOR)
-  implementation(LibraryDependency.LOTTIE)
-  implementation(LibraryDependency.TOASTY)
-  implementation(LibraryDependency.WORK_MANAGER)
+    implementation(LibraryDependency.CORE_KTX)
+    implementation(LibraryDependency.FRAGMENT_KTX)
+    implementation(LibraryDependency.MATERIAL)
+    implementation(LibraryDependency.LIFECYCLE_KTX)
+    implementation(LibraryDependency.BILLING)
+    implementation(LibraryDependency.NAVIGATOR)
+    implementation(LibraryDependency.LOTTIE)
+    implementation(LibraryDependency.TOASTY)
+    implementation(LibraryDependency.WORK_MANAGER)
 
-  implementation(LibraryDependency.HILT_WORK_MANAGER)
-  kapt(LibraryDependency.HILT_WORK_MANAGER_COMPILER)
+    implementation(LibraryDependency.HILT_WORK_MANAGER)
+    kapt(LibraryDependency.HILT_WORK_MANAGER_COMPILER)
 
-  implementation(LibraryDependency.HILT_ANDROID)
-  kapt(LibraryDependency.HILT_COMPILER)
+    implementation(LibraryDependency.HILT_ANDROID)
+    kapt(LibraryDependency.HILT_COMPILER)
 }

--- a/XClipper.Android/modules/core-extension/build.gradle.kts
+++ b/XClipper.Android/modules/core-extension/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id(GradlePluginId.ANDROID_LIBRARY)
     id(GradlePluginId.XCLIPPER_ANDROID)
     kotlin(GradlePluginId.ANDROID_KTX)
-    kotlin("kapt")
+    kotlin(GradlePluginId.KAPT)
 }
 
 android {

--- a/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Clip.kt
+++ b/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Clip.kt
@@ -54,7 +54,7 @@ data class Clip(
     companion object {
         private const val FULL_DATA_FORMAT = "dd MMM yyyy, hh:mm a"
 
-        fun fromJson(model: String): Clip = ClipConverter.fromStringToClip(model)!!
+        fun fromJson(json: String): Clip = ClipConverter.fromStringToClip(json)!!
 
         /**
          * Generates Clip data along with the properties "data", "time"

--- a/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Clip.kt
+++ b/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Clip.kt
@@ -1,5 +1,6 @@
 package com.kpstv.xclipper.data.model
 
+import android.os.Parcelable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -12,6 +13,7 @@ import com.kpstv.xclipper.data.converters.DateFormatConverter
 import com.kpstv.xclipper.extensions.ClipTagMap
 import com.kpstv.xclipper.extensions.Logger
 import com.kpstv.xclipper.extensions.utils.ClipUtils
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.*
@@ -158,7 +160,8 @@ enum class ClipTag(val marker: Int) {
     }
 }
 
-enum class ClipTagType {
+@Parcelize
+enum class ClipTagType : Parcelable {
     /**
      * System tags are phone, date, url that are automatically assigned based on text recognition.
      */

--- a/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Dictionary.kt
+++ b/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Dictionary.kt
@@ -1,7 +1,11 @@
 package com.kpstv.xclipper.data.model
 
+import android.os.Parcelable
 import com.kpstv.bindings.AutoGenerateListConverter
 import com.kpstv.bindings.ConverterType
+import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 @AutoGenerateListConverter(using = ConverterType.GSON)
-data class Dictionary<K, V>(val key: K, val value: V)
+@Parcelize
+data class Dictionary<K : Serializable, V : Serializable>(val key: K, val value: V) : Parcelable

--- a/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Tag.kt
+++ b/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/data/model/Tag.kt
@@ -1,15 +1,18 @@
 package com.kpstv.xclipper.data.model
 
+import android.os.Parcelable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.kpstv.bindings.AutoGenerateConverter
 import com.kpstv.bindings.AutoGenerateListConverter
 import com.kpstv.bindings.ConverterType
+import kotlinx.parcelize.Parcelize
 
 @Entity(tableName = "table_tag")
 @AutoGenerateConverter(using = ConverterType.GSON)
 @AutoGenerateListConverter(using = ConverterType.GSON)
+@Parcelize
 data class Tag(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "id")
@@ -18,7 +21,7 @@ data class Tag(
     val name: String,
     @ColumnInfo(name = "type")
     val type: ClipTagType
-) {
+) : Parcelable {
 
     fun getClipTag() : ClipTag? = ClipTag.fromValue(name)
     companion object {

--- a/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/extensions/SaveRestore.kt
+++ b/XClipper.Android/modules/core/src/main/java/com/kpstv/xclipper/extensions/SaveRestore.kt
@@ -1,0 +1,8 @@
+package com.kpstv.xclipper.extensions
+
+import android.os.Bundle
+
+interface SaveRestore {
+    fun saveState(bundle: Bundle)
+    fun restoreState(bundle: Bundle?)
+}

--- a/XClipper.Android/modules/feature-home/build.gradle.kts
+++ b/XClipper.Android/modules/feature-home/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id(GradlePluginId.XCLIPPER_ANDROID)
     kotlin(GradlePluginId.ANDROID_KTX)
     kotlin(GradlePluginId.KAPT)
+    id(GradlePluginId.KOTLIN_PARCELIZE)
     id(GradlePluginId.DAGGER_HILT)
 }
 
@@ -31,9 +32,13 @@ dependencies {
     implementation(LibraryDependency.PAGING)
     implementation(LibraryDependency.TOASTY)
     implementation(LibraryDependency.BALLOON)
+    implementation(LibraryDependency.GSON)
 
     implementation(LibraryDependency.ROOM_KTX)
     kapt(LibraryDependency.ROOM_COMPILER_KAPT)
+
+    implementation(LibraryDependency.AUTO_BINDINGS)
+    kapt(LibraryDependency.AUTO_BINDINGS_COMPILER)
 
     implementation(LibraryDependency.HILT_ANDROID)
     kapt(LibraryDependency.HILT_COMPILER)

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/extension/enumeration/SpecialTagFilter.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/extension/enumeration/SpecialTagFilter.kt
@@ -1,13 +1,16 @@
 package com.kpstv.xclipper.extension.enumeration
 
+import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.kpstv.xclipper.feature_home.R
+import kotlinx.parcelize.Parcelize
 
 /**
  * Each tag has some effects on the behavior of how lists of clips are shown.
  */
-enum class SpecialTagFilter(@StringRes val stringRes: Int, @DrawableRes val drawableRes: Int) {
+@Parcelize
+enum class SpecialTagFilter(@StringRes val stringRes: Int, @DrawableRes val drawableRes: Int) : Parcelable {
     Invert(R.string.invert, R.drawable.ic_filter_reverse), // inverts the list with the applied filter
     Pin(R.string.pin, R.drawable.ic_pin); // filters the list that are pinned
 

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/adapter/ClipAdapter.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/adapter/ClipAdapter.kt
@@ -18,7 +18,6 @@ import com.kpstv.xclipper.feature_home.databinding.ItemClipBinding
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_CLICK_COLOR
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_COLOR
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_SELECTED_COLOR
-import okhttp3.internal.filterList
 
 data class ClipAdapterItem constructor(
     val clip: Clip,

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/adapter/ClipAdapter.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/adapter/ClipAdapter.kt
@@ -4,9 +4,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -21,30 +18,32 @@ import com.kpstv.xclipper.feature_home.databinding.ItemClipBinding
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_CLICK_COLOR
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_COLOR
 import com.kpstv.xclipper.ui.helpers.AppThemeHelper.CARD_SELECTED_COLOR
+import okhttp3.internal.filterList
 
-data class ClipAdapterItem constructor(val clip: Clip) {
-    var expanded: Boolean = false
-
+data class ClipAdapterItem constructor(
+    val clip: Clip,
+    var expanded: Boolean = false,
+    var selected: Boolean = false,
+    var selectedClipboard: Boolean = false,
+    var multiSelectionState: Boolean = false
+) {
     companion object {
         fun from(clip: Clip) = ClipAdapterItem(clip = clip)
+
+        fun List<ClipAdapterItem>.toClips(): List<Clip> = map { it.clip }
     }
 }
 
 class ClipAdapter(
-    private val lifecycleOwner: LifecycleOwner,
-    private val multiSelectionState: LiveData<Boolean>,
-    private val selectedItem: LiveData<Clip>,
-    private val currentClip: LiveData<String>,
-    private val onClick: (Clip, Int) -> Unit,
-    private val onLongClick: (Clip, Int) -> Unit,
-    private val selectedClips: LiveData<List<Clip>>
-) : ListAdapter<Clip, ClipAdapterHolder>(DiffCallback.asConfig(isBackground = true)) {
+    private val onClick: (ClipAdapterItem, Int) -> Unit,
+    private val onLongClick: (ClipAdapterItem, Int) -> Unit,
+) : ListAdapter<ClipAdapterItem, ClipAdapterHolder>(DiffCallback.asConfig(isBackground = true)) {
 
-    private object DiffCallback : DiffUtil.ItemCallback<Clip>() {
-        override fun areItemsTheSame(oldItem: Clip, newItem: Clip): Boolean =
-            oldItem.data == newItem.data
+    private object DiffCallback : DiffUtil.ItemCallback<ClipAdapterItem>() {
+        override fun areItemsTheSame(oldItem: ClipAdapterItem, newItem: ClipAdapterItem): Boolean =
+            oldItem.clip.data == newItem.clip.data
 
-        override fun areContentsTheSame(oldItem: Clip, newItem: Clip): Boolean = oldItem == newItem
+        override fun areContentsTheSame(oldItem: ClipAdapterItem, newItem: ClipAdapterItem): Boolean = oldItem.clip == newItem.clip
     }
 
     private val TAG = javaClass.simpleName
@@ -52,10 +51,6 @@ class ClipAdapter(
     private lateinit var copyClick: (Clip, Int) -> Unit
     private lateinit var menuClick: (Clip, Int, MenuType) -> Unit
 
-    private val selectedDataObservers = HashMap<Int, Observer<String>>()
-    private val selectedItemObservers = HashMap<Int, Observer<Clip>>()
-    private val multiSelectionObservers = HashMap<Int, Observer<Boolean>>()
-    private val selectedClipsObservers = HashMap<Int, Observer<List<Clip>>>()
     private var trimClipText : Boolean = false
     private var loadImageMarkdownText : Boolean = true
 
@@ -82,31 +77,47 @@ class ClipAdapter(
                     true
                 }
                 ciCopyButton.setOnClickListener {
-                    val clip = getItem(bindingAdapterPosition)
+                    val clip = getItem(bindingAdapterPosition).clip
                     copyClick.invoke(clip, bindingAdapterPosition)
                 }
                 ciBtnEdit.setOnClickListener {
-                    val clip = getItem(bindingAdapterPosition)
+                    val clip = getItem(bindingAdapterPosition).clip
                     menuClick.invoke(clip, bindingAdapterPosition, MenuType.Edit)
                 }
                 ciBtnPin.setOnClickListener {
-                    val clip = getItem(bindingAdapterPosition)
+                    val clip = getItem(bindingAdapterPosition).clip
                     menuClick.invoke(clip, bindingAdapterPosition, MenuType.Pin)
                 }
                 ciBtnSpecial.setOnClickListener {
-                    val clip = getItem(bindingAdapterPosition)
+                    val clip = getItem(bindingAdapterPosition).clip
                     menuClick.invoke(clip, bindingAdapterPosition, MenuType.Special)
                 }
                 ciBtnShare.setOnClickListener {
-                    val clip = getItem(bindingAdapterPosition)
+                    val clip = getItem(bindingAdapterPosition).clip
                     menuClick.invoke(clip, bindingAdapterPosition, MenuType.Share)
                 }
             }
         }
     }
 
+    override fun onBindViewHolder(holder: ClipAdapterHolder, position: Int, payloads: MutableList<Any>) {
+        val clipAdapterItem = getItem(position)
+        for (payload in payloads) {
+            when(payload) {
+                ClipAdapterHolder.Payloads.UpdateExpandedState -> holder.applyForExpandedItem(clipAdapterItem)
+                ClipAdapterHolder.Payloads.UpdateSelectedState -> holder.applyForSelectedItem(clipAdapterItem)
+                ClipAdapterHolder.Payloads.UpdateMultiSelectionState -> holder.applyForMultiSelectionState(clipAdapterItem)
+                ClipAdapterHolder.Payloads.UpdateCurrentClipboardText -> holder.applyForCurrentClipboardText(clipAdapterItem)
+            }
+        }
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        }
+    }
+
     override fun onBindViewHolder(holder: ClipAdapterHolder, position: Int) = with(holder) {
-        val clip = getItem(position)
+        val clipAdapterItem = getItem(position)
+        val clip = clipAdapterItem.clip
 
         binding.ciTextView.text = if (trimClipText) clip.data.trim() else clip.data
         binding.root.tag = clip.id // used for unsubscribing.
@@ -128,29 +139,78 @@ class ClipAdapter(
         updateTags(clip)
         updateHolderTags(clip)
 
-        val selectedDataObserver: Observer<String> = Observer { current ->
-            applyForCurrentClipboardText(current)
-        }
-        val selectedItemObserver: Observer<Clip> = Observer { selectedClip ->
-            applyForSelectedItem(clip, isExpanded = selectedClip == clip)
-        }
-        val multiSelectionObserver: Observer<Boolean> = Observer { state ->
-            applyForMultiSelectionState(clip, isMultiSelectionState = state)
-        }
-        val selectedClipsObserver: Observer<List<Clip>> = Observer { clips ->
-            applyForSelectedClips(clip, isExpanded = selectedItem.value == clip, clips)
-        }
-
-        // no need to remove these observers from hashmap as it will guarantee to not create duplicates causing memory leaks.
-
-        currentClip.observe(lifecycleOwner, selectedDataObserver).also { selectedDataObservers[clip.id] = selectedDataObserver }
-        selectedItem.observe(lifecycleOwner, selectedItemObserver).also { selectedItemObservers[clip.id] = selectedItemObserver }
-        multiSelectionState.observe(lifecycleOwner, multiSelectionObserver).also { multiSelectionObservers[clip.id] = multiSelectionObserver }
-        selectedClips.observe(lifecycleOwner, selectedClipsObserver).also { selectedClipsObservers[clip.id] = selectedClipsObserver }
+        applyForCurrentClipboardText(clipAdapterItem)
+        applyForExpandedItem(clipAdapterItem)
+        applyForMultiSelectionState(clipAdapterItem)
+        applyForSelectedItem(clipAdapterItem)
     }
 
-    fun updateSelectedItem(clip: Clip?) {
-//        val position = currentList.i
+    fun updateItemsForMultiSelectionState(isMultiSelectionState: Boolean) {
+        for (item in currentList) {
+            item.multiSelectionState = isMultiSelectionState
+        }
+        notifyItemRangeChanged(0, currentList.size, ClipAdapterHolder.Payloads.UpdateMultiSelectionState)
+    }
+
+    fun updateCurrentClipboardItem(text: String?) {
+        val currentClipboardItem = currentList.firstOrNull { it.selectedClipboard }
+        if (text == null || currentClipboardItem?.clip?.data != text) {
+            currentClipboardItem?.let { item ->
+                val position = currentList.indexOf(item)
+                item.selectedClipboard = false
+                notifyItemChanged(position, ClipAdapterHolder.Payloads.UpdateCurrentClipboardText)
+            }
+        }
+
+        if (text != null) {
+            val item = currentList.firstOrNull { it.clip.data == text } ?: return
+            val position = currentList.indexOf(item)
+            item.selectedClipboard = true
+            notifyItemChanged(position, ClipAdapterHolder.Payloads.UpdateCurrentClipboardText)
+        }
+    }
+
+    fun updateExpandedItem(clip: ClipAdapterItem) {
+        val currentExpandedItemPosition = currentList.indexOfFirst { it.expanded }
+        val position = currentList.indexOf(clip)
+
+        if (currentExpandedItemPosition != -1 && currentExpandedItemPosition != position) {
+            clearExpandedItem()
+        }
+
+        clip.expanded = !clip.expanded
+        notifyItemChanged(position, ClipAdapterHolder.Payloads.UpdateExpandedState)
+    }
+
+    fun clearExpandedItem() {
+        val clipAdapterItem = currentList.firstOrNull { it.expanded } ?: return
+        val position = currentList.indexOf(clipAdapterItem)
+        clipAdapterItem.expanded = false
+        notifyItemChanged(position)
+    }
+
+    fun addToSelectionItems(clips: List<ClipAdapterItem>) {
+        for(item in currentList) {
+            item.selected = false
+        }
+        for(item in clips) {
+            item.selected = true
+        }
+        notifyItemRangeChanged(0, currentList.size, ClipAdapterHolder.Payloads.UpdateSelectedState)
+    }
+
+    fun updateAllItemsToSelectedState() {
+        updateSelectionStateForAllItems(isSelected = true)
+    }
+
+    fun clearAllSelectedItems() {
+        updateSelectionStateForAllItems(isSelected = false)
+    }
+    private fun updateSelectionStateForAllItems(isSelected: Boolean) {
+        for(item in currentList) {
+            item.selected = isSelected
+        }
+        notifyItemRangeChanged(0, currentList.size, ClipAdapterHolder.Payloads.UpdateSelectedState)
     }
 
     fun setCopyClick(block: (Clip, Int) -> Unit) {
@@ -161,7 +221,7 @@ class ClipAdapter(
         this.menuClick = block
     }
 
-    fun getItemAt(pos: Int): Clip = getItem(pos)
+    fun getItemAt(pos: Int): ClipAdapterItem = getItem(pos)
 
     enum class MenuType {
         Edit, Pin, Special, Share
@@ -174,9 +234,9 @@ class ClipAdapterHolder(val binding: ItemClipBinding) : RecyclerView.ViewHolder(
 
     private val context = binding.root.context
 
-    fun applyForSelectedItem(clip: Clip, isExpanded: Boolean = false): Unit = with(binding) {
-        updatePinButton(clip)
-        if (isExpanded) {
+    fun applyForExpandedItem(clipAdapterItem: ClipAdapterItem): Unit = with(binding) {
+        updatePinButton(clipAdapterItem.clip)
+        if (clipAdapterItem.expanded) {
             hiddenLayout.show()
             mainCard.setCardBackgroundColor(CARD_CLICK_COLOR)
             mainCard.cardElevation = context.toPx(3)
@@ -187,18 +247,16 @@ class ClipAdapterHolder(val binding: ItemClipBinding) : RecyclerView.ViewHolder(
         }
     }
 
-    fun applyForCurrentClipboardText(current: String): Unit = with(binding) {
-        if (ciTextView.text == current)
-            ciTextView.setTextColor(
-                context.getColorAttr(R.attr.colorCurrentClip)
-            )
-        else ciTextView.setTextColor(
-            context.getColorAttr(R.attr.colorTextPrimary)
-        )
+    fun applyForCurrentClipboardText(clipAdapterItem: ClipAdapterItem): Unit = with(binding) {
+        if (clipAdapterItem.selectedClipboard) {
+            ciTextView.setTextColor(context.getColorAttr(R.attr.colorCurrentClip))
+        } else {
+            ciTextView.setTextColor(context.getColorAttr(R.attr.colorTextPrimary))
+        }
     }
 
-    fun applyForMultiSelectionState(clip: Clip, isMultiSelectionState: Boolean): Unit = with(binding) {
-        if (isMultiSelectionState) {
+    fun applyForMultiSelectionState(clipAdapterItem: ClipAdapterItem): Unit = with(binding) {
+        if (clipAdapterItem.multiSelectionState) {
             ciCopyButton.hide()
             ciTimeText.hide()
             ciTagLayout.hide()
@@ -207,26 +265,17 @@ class ClipAdapterHolder(val binding: ItemClipBinding) : RecyclerView.ViewHolder(
             ciCopyButton.show()
             ciTimeText.show()
             ciTagLayout.show()
-            if (clip.isPinned) {
+            if (clipAdapterItem.clip.isPinned) {
                 ciPinImage.show()
             }
         }
     }
 
-    fun applyForSelectedClips(clip: Clip, isExpanded: Boolean, selectedClips: List<Clip>?): Unit = with(binding) {
-        if (selectedClips == null) return
-        when {
-            selectedClips.contains(clip) -> {
-                mainCard.setCardBackgroundColor(CARD_SELECTED_COLOR)
-            }
-            else -> {
-                /**
-                * We are also checking if clip is expanded. Since for large item set
-                * it kinda forgets about it due to recreation of whole list.
-                */
-                if (!isExpanded)
-                    mainCard.setCardBackgroundColor(CARD_COLOR)
-            }
+    fun applyForSelectedItem(clipAdapterItem: ClipAdapterItem): Unit = with(binding) {
+        if (clipAdapterItem.selected) {
+            mainCard.setCardBackgroundColor(CARD_SELECTED_COLOR)
+        } else if (!clipAdapterItem.expanded) {
+            mainCard.setCardBackgroundColor(CARD_COLOR)
         }
     }
 
@@ -296,7 +345,10 @@ class ClipAdapterHolder(val binding: ItemClipBinding) : RecyclerView.ViewHolder(
     }
 
     enum class Payloads {
-        UpdateSelectedItem
+        UpdateExpandedState,
+        UpdateSelectedState,
+        UpdateMultiSelectionState,
+        UpdateCurrentClipboardText
     }
 }
 

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/dialogs/EditDialog.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/dialogs/EditDialog.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class EditDialog : AppCompatActivity() {
 
-    companion object {
-        const val STATE_DIALOG_TEXT_FIELD = "state_dialog_text_field"
-        const val STATE_TAG_RECYCLERVIEW = "state_tag_recyclerview"
+    private companion object {
+        private const val STATE_DIALOG_TEXT_FIELD = "state_dialog_text_field"
+        private const val STATE_TAG_RECYCLERVIEW = "state_tag_recyclerview"
 
         private const val STAGGERED_SPAN_COUNT = 2
         private const val STAGGERED_SPAN_COUNT_MIN = 1
@@ -43,6 +43,8 @@ class EditDialog : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        mainViewModel.editManager.restoreState(savedInstanceState)
 
         HomeThemeHelper.apply(this)
 
@@ -182,6 +184,11 @@ class EditDialog : AppCompatActivity() {
         }
         onSaveInstanceState(bundle)
         super.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        mainViewModel.editManager.saveState(outState)
+        super.onSaveInstanceState(outState)
     }
 
     override fun onDestroy() {

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
@@ -198,14 +198,9 @@ class Home : ValueFragment(R.layout.fragment_home) {
             if (mainViewModel.stateManager.isMultiSelectionStateActive() && clips?.isEmpty() == true)
                 mainViewModel.stateManager.setToolbarState(ToolbarState.NormalViewState)
 
-            binding.toolbar.menu.findItem(R.id.action_mergeAll)?.isVisible =
-                mainViewModel.stateManager.isMultiSelectionStateActive() && clips.size > 1
+            binding.toolbar.menu.findItem(R.id.action_mergeAll)?.isVisible = mainViewModel.stateManager.isMultiSelectionStateActive() && clips.size > 1
         }
-        combineTuple(
-            mainViewModel.searchManager.searchFilters,
-            mainViewModel.searchManager.tagFilters,
-            mainViewModel.searchManager.specialTagFilters
-        )
+        combineTuple(mainViewModel.searchManager.searchFilters, mainViewModel.searchManager.tagFilters, mainViewModel.searchManager.specialTagFilters)
             .observe(viewLifecycleOwner) { (searchFilters: List<String>?, tagFilters: List<Tag>?, specialTagFilters: List<SpecialTagFilter>?) ->
                 if (searchFilters == null || tagFilters == null || specialTagFilters == null) return@observe
                 updateSearchAndTagFilters(searchFilters, tagFilters, specialTagFilters)
@@ -263,10 +258,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
         }
 
         adapter.setCopyClick { clip, _ ->
-            clipboardProvider.setClipboard(
-                data = clip.data,
-                flag = ClipboardProviderFlags.IgnoreObservedAction
-            )
+            clipboardProvider.setClipboard(data = clip.data, flag = ClipboardProviderFlags.IgnoreObservedAction)
             Toasty.info(requireContext(), getString(R.string.copy_to_clipboard)).show()
         }
 

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
@@ -103,6 +103,16 @@ class Home : ValueFragment(R.layout.fragment_home) {
         registerForThemeChange()
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mainViewModel.searchManager.restoreState(savedInstanceState)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        mainViewModel.searchManager.saveState(outState)
+        super.onSaveInstanceState(outState)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
@@ -191,8 +191,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
                     binding.fabAddItem.hide()
                     swipeToDeleteItemTouch.attachToRecyclerView(null)
                 }
-                else -> { /* no-op */
-                }
+                else -> { /* no-op */ }
             }
         }
         mainViewModel.stateManager.selectedItemClips.observe(viewLifecycleOwner) { clips ->
@@ -311,11 +310,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
                     swipeToDeleteItemTouch.attachToRecyclerView(null)
             }
 
-            RecyclerViewInsetHelper().attach(
-                ciRecyclerView,
-                RecyclerViewInsetHelper.InsetType.BOTTOM,
-                true
-            )
+            RecyclerViewInsetHelper().attach(ciRecyclerView, RecyclerViewInsetHelper.InsetType.BOTTOM, true)
             recyclerViewScrollHelper.attach(
                 ciRecyclerView,
                 onScrollDown = {
@@ -380,17 +375,12 @@ class Home : ValueFragment(R.layout.fragment_home) {
     }
 
     private fun showUndoAndDelete(itemsToRemove: List<ClipAdapterItem>) {
-        val containsLogTagItem =
-            itemsToRemove.any { it.clip.tags?.containsKey(ClipTag.LOCK.small()) == true }
+        val containsLogTagItem = itemsToRemove.any { it.clip.tags?.containsKey(ClipTag.LOCK.small()) == true }
         if (containsLogTagItem) {
-            Toasty.warning(
-                requireContext(),
-                getString(R.string.error_delete_lock_tag, getString(ClipTag.LOCK.titleRes))
-            ).show()
+            Toasty.warning(requireContext(), getString(R.string.error_delete_lock_tag, getString(ClipTag.LOCK.titleRes))).show()
         }
 
-        val finalItemsToRemove =
-            itemsToRemove.filterNot { it.clip.tags?.containsKey(ClipTag.LOCK.small()) == true }
+        val finalItemsToRemove = itemsToRemove.filterNot { it.clip.tags?.containsKey(ClipTag.LOCK.small()) == true }
 
         if (finalItemsToRemove.isEmpty()) return
 
@@ -492,19 +482,14 @@ class Home : ValueFragment(R.layout.fragment_home) {
                 mainViewModel.searchManager.clearSearch()
             }
         )
-        searchView.setOnSearchViewListener(object :
-            SimpleSearchView.SearchViewListener by DefaultSearchViewListener {
+        searchView.setOnSearchViewListener(object : SimpleSearchView.SearchViewListener by DefaultSearchViewListener {
             override fun onSearchViewClosed() {
                 mainViewModel.searchManager.clearSearch()
             }
         })
     }
 
-    private fun updateSearchAndTagFilters(
-        searches: List<String>,
-        tags: List<Tag>,
-        specialTags: List<SpecialTagFilter>
-    ) {
+    private fun updateSearchAndTagFilters(searches: List<String>, tags: List<Tag>, specialTags: List<SpecialTagFilter>) {
         binding.ciChipGroup.removeAllViews()
         searches.forEach { query ->
             binding.ciChipGroup.addView(
@@ -571,9 +556,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
         toolbar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
         toolbar.inflateMenu(R.menu.normal_menu)
 
-        val syncImage =
-            LayoutInflater.from(requireContext())
-                .inflate(R.layout.imageview_menu_item, null) as ImageView
+        val syncImage = LayoutInflater.from(requireContext()).inflate(R.layout.imageview_menu_item, null) as ImageView
 
         syncImage.apply {
             setOnClickListener {
@@ -606,8 +589,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
             }
         }
 
-        val settingImage = LayoutInflater.from(requireContext())
-            .inflate(R.layout.imageview_menu_setting, null) as ImageView
+        val settingImage = LayoutInflater.from(requireContext()).inflate(R.layout.imageview_menu_setting, null) as ImageView
         settingImage.setOnClickListener {
             settingsNavigation.navigate()
         }
@@ -641,10 +623,7 @@ class Home : ValueFragment(R.layout.fragment_home) {
             view.children.forEach loop@{ child ->
                 if (child is RecyclerView) {
                     child.addOnItemTouchListener(object : RecyclerView.OnItemTouchListener {
-                        override fun onInterceptTouchEvent(
-                            rv: RecyclerView,
-                            e: MotionEvent
-                        ): Boolean {
+                        override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
                             return onTouchListener.onTouch(rv, e)
                         }
 

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/fragments/Home.kt
@@ -67,17 +67,12 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class Home : ValueFragment(R.layout.fragment_home) {
 
-    @Inject
-    lateinit var clipboardProvider: ClipboardProvider
-    @Inject
-    lateinit var appSettings: AppSettings
-    @Inject
-    lateinit var firebaseProviderHelper: FirebaseProviderHelper
+    @Inject lateinit var clipboardProvider: ClipboardProvider
+    @Inject lateinit var appSettings: AppSettings
+    @Inject lateinit var firebaseProviderHelper: FirebaseProviderHelper
 
-    @Inject
-    lateinit var settingsNavigation: SettingsNavigation
-    @Inject
-    lateinit var specialSheetNavigation: SpecialSheetNavigation
+    @Inject lateinit var settingsNavigation: SettingsNavigation
+    @Inject lateinit var specialSheetNavigation: SpecialSheetNavigation
 
     private lateinit var adapter: ClipAdapter
     private var undoSnackBar: Snackbar? = null

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/viewmodel/manager/MainSearchManager.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/viewmodel/manager/MainSearchManager.kt
@@ -1,14 +1,16 @@
 package com.kpstv.xclipper.ui.viewmodel.manager
 
+import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.kpstv.xclipper.data.model.Tag
 import com.kpstv.xclipper.extension.enumeration.SpecialTagFilter
+import com.kpstv.xclipper.extensions.SaveRestore
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class MainSearchManager @Inject constructor() {
+class MainSearchManager @Inject constructor() : SaveRestore {
 
     private val _searchString = MutableLiveData("")
     private val _searchArrayFilter = MutableLiveData<List<String>>(emptyList())
@@ -124,6 +126,31 @@ class MainSearchManager @Inject constructor() {
         clearAllSearchFilter()
         clearAllTagFilter()
         clearAllSpecialTag()
+    }
+
+    override fun saveState(bundle: Bundle) {
+        val out = Bundle().apply {
+            _searchArrayFilter.value?.let { putStringArrayList(KEY_SEARCH_ARRAY, ArrayList(it)) }
+            _tagArrayFilter.value?.let { putParcelableArrayList(KEY_TAG_ARRAY, ArrayList(it)) }
+            _specialTagFilter.value?.let { putParcelableArrayList(KEY_SPECIAL_ARRAY, ArrayList(it)) }
+        }
+        bundle.putBundle(SAVE_KEY, out)
+    }
+
+    override fun restoreState(bundle: Bundle?) {
+        bundle?.getBundle(SAVE_KEY)?.let { out ->
+            out.getStringArrayList(KEY_SEARCH_ARRAY)?.let { _searchArrayFilter.postValue(it) }
+            out.getParcelableArrayList<Tag>(KEY_TAG_ARRAY)?.let { _tagArrayFilter.postValue(it) }
+            out.getParcelableArrayList<SpecialTagFilter>(KEY_SPECIAL_ARRAY)?.let { _specialTagFilter.postValue(it) }
+        }
+    }
+
+    private companion object {
+        private const val SAVE_KEY = "com.kpstv.xclipper:MainSearchManager"
+
+        private const val KEY_SEARCH_ARRAY = "searchArray"
+        private const val KEY_TAG_ARRAY = "tagArray"
+        private const val KEY_SPECIAL_ARRAY = "specialArray"
     }
     private val TAG = javaClass.simpleName
 }

--- a/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/viewmodel/manager/MainStateManager.kt
+++ b/XClipper.Android/modules/feature-home/src/main/java/com/kpstv/xclipper/ui/viewmodel/manager/MainStateManager.kt
@@ -3,9 +3,9 @@ package com.kpstv.xclipper.ui.viewmodel.manager
 import android.annotation.SuppressLint
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.kpstv.xclipper.data.model.Clip
 import com.kpstv.xclipper.extension.enumeration.DialogState
 import com.kpstv.xclipper.extension.enumeration.ToolbarState
+import com.kpstv.xclipper.ui.adapter.ClipAdapterItem
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,12 +21,12 @@ class MainStateManager @Inject constructor() {
     private val _dialogState: MutableLiveData<DialogState> =
         MutableLiveData(DialogState.Normal)
 
-    private val _selectedItemClips = MutableLiveData<List<Clip>>()
+    private val _selectedItemClips = MutableLiveData<List<ClipAdapterItem>>()
     private val _isMultiSelectionEnabled = MutableLiveData<Boolean>()
 
-    private val _selectedItem = MutableLiveData<Clip>()
+    private val _expandedItem = MutableLiveData<ClipAdapterItem>()
 
-    val selectedItemClips: LiveData<List<Clip>>
+    val selectedItemClips: LiveData<List<ClipAdapterItem>>
         get() = _selectedItemClips
 
     val toolbarState: LiveData<ToolbarState>
@@ -35,8 +35,8 @@ class MainStateManager @Inject constructor() {
     val dialogState: LiveData<DialogState>
         get() = _dialogState
 
-    val selectedItem: LiveData<Clip>
-        get() = _selectedItem
+    val expandedItem: LiveData<ClipAdapterItem>
+        get() = _expandedItem
 
     fun setToolbarState(state: ToolbarState) =
         _toolbarState.postValue(state)
@@ -53,7 +53,7 @@ class MainStateManager @Inject constructor() {
     val multiSelectionState: LiveData<Boolean>
         get() = _isMultiSelectionEnabled
 
-    fun addOrRemoveClipFromSelectedList(clip: Clip) {
+    fun addOrRemoveClipFromSelectedList(clip: ClipAdapterItem) {
         var list = _selectedItemClips.value?.toMutableList()
         if (list == null)
             list = ArrayList()
@@ -67,26 +67,30 @@ class MainStateManager @Inject constructor() {
         _selectedItemClips.postValue(list)
     }
 
-    fun addOrRemoveSelectedItem(clip: Clip) {
-        _selectedItem.value?.let {
+    fun addOrRemoveExpandedItem(clip: ClipAdapterItem) {
+        _expandedItem.value?.let {
             if (it == clip) {
-                clearSelectedItem()
+                clearExpandedItem()
                 return
             }
         }
-        _selectedItem.postValue(clip)
+        _expandedItem.postValue(clip)
     }
 
-    fun clearSelectedItem() {
-        _selectedItem.postValue(null)
+    fun clearExpandedItem() {
+        _expandedItem.postValue(null)
     }
 
-    fun addAllToSelectedList(clips: ArrayList<Clip>) {
+    fun addAllToSelectedList(clips: List<ClipAdapterItem>) {
         _selectedItemClips.postValue(clips)
     }
 
     fun clearSelectedList() {
-        _selectedItemClips.postValue(ArrayList())
+        _selectedItemClips.postValue(emptyList())
+    }
+
+    fun repostMultiSelectionState() {
+        _isMultiSelectionEnabled.postValue(_isMultiSelectionEnabled.value)
     }
 
     init {


### PR DESCRIPTION
We were subscribing to LiveData observers in `onBindViewHolder` on RecyclerView, this should not be done as it will resubscribe the observers multiple times whenever `onBindViewHolder` is called.

There are other performance issues that this PR will target to resolve.

Additional changes,
- Search filters will be saved across process death.
- Edit dialog configs will be saved across process death.